### PR TITLE
logging: IPv4 packet received should be trace

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -152,7 +152,7 @@ impl Ipv4Rx {
     fn forward(&self, time: SystemTime, ip_pkg: Ipv4Packet) -> RxResult {
         let dest_ip = ip_pkg.get_destination();
         let next_level_protocol = ip_pkg.get_next_level_protocol();
-        debug!("Ipv4 got a packet to {}!", dest_ip);
+        trace!("Ipv4 got a packet to {}!", dest_ip);
         let mut listeners = try!(self.listeners.lock().or(Err(RxError::PoisonedLock)));
         if let Some(mut listeners) = listeners.get_mut(&dest_ip) {
             if let Some(mut listener) = listeners.get_mut(&next_level_protocol) {


### PR DESCRIPTION
Change the per IPv4 packet received log to trace. This allows us to use debug level logging for an application and its dependencies without being overwhelmed with logging. 